### PR TITLE
Remove Any and Clone restrictions

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -1,5 +1,4 @@
 use options::Options;
-use std::any::Any;
 use std::str::FromStr;
 
 /// Command-line arguments.
@@ -16,7 +15,7 @@ pub struct Arguments {
 impl Arguments {
     /// Get the value of an option (if present) converted to a specific type (if
     /// possible).
-    pub fn get<T: Any + Clone + FromStr>(&self, name: &str) -> Option<T> {
+    pub fn get<T: FromStr>(&self, name: &str) -> Option<T> {
         self.options.get_ref::<String>(name).and_then(|string| string.parse().ok())
     }
 }


### PR DESCRIPTION
I like your lib. It's extremelly simple, tiny and flexible.

I've removed some restrictions with reasons:
- `Any` - library bootstraps data from string and never downcasting it
- `Clone` - not necessary if somebody want to bootstrap something fat, but not cloneable, like: `--from-json="{value:...}"`

I think It makes lib even more flexible. Tests were passed.
